### PR TITLE
Update plugin.xml to add required framework references

### DIFF
--- a/BB10-Cordova/simplexpbeaconplugin/plugin/plugin.xml
+++ b/BB10-Cordova/simplexpbeaconplugin/plugin/plugin.xml
@@ -46,6 +46,9 @@
 
         <header-file src="src/ios/SimpleXpBeaconPlugin.h" target-dir="SimpleXpBeaconPlugin"/>
         <source-file src="src/ios/SimpleXpBeaconPlugin.m" target-dir="SimpleXpBeaconPlugin"/>
+    	
+    	<framework src="CoreBluetooth.framework" />
+    	<framework src="CoreLocation.framework" />        
     </platform>
 
 </plugin>


### PR DESCRIPTION
When the plugin is added to a project with cordova-ios, linking fails because the CoreBluetooth and CoreLocation frameworks are not referenced in the project.

```
cordova create beaconTest
cd beaconTest
cordova plugin add cordova-plugin-beacon
cordova platform add ios@3.9.2
cordova build ios
...
Undefined symbols for architecture i386:
  "_CBCentralManagerOptionShowPowerAlertKey", referenced from:
      -[SimpleXpBeaconPlugin initialiseBluetooth:] in SimpleXpBeaconPlugin.o
  "_OBJC_CLASS_$_CBCentralManager", referenced from:
      objc-class-ref in SimpleXpBeaconPlugin.o
  "_OBJC_CLASS_$_CLBeaconRegion", referenced from:
      objc-class-ref in SimpleXpBeaconPlugin.o
  "_OBJC_CLASS_$_CLLocationManager", referenced from:
      objc-class-ref in SimpleXpBeaconPlugin.o
ld: symbol(s) not found for architecture i386
clang: error: linker command failed with exit code 1 (use -v to see invocation)

** BUILD FAILED **
```

Adding framework references allows symbols to be resolved and the build succeeds.
Tested with cordova-ios@3.9.2 and XCode 7.2 but probably not specific to those versions.

I considered making the framework references weak ([weak="true"](https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#link-19)), but it seems like if this plugin is being added, the app would not work without it, so I don't think making them weak makes sense.
